### PR TITLE
[bug] telepresence Pod in the start-up so that is not killed

### DIFF
--- a/telepolice/telepolice.go
+++ b/telepolice/telepolice.go
@@ -286,11 +286,12 @@ func (te *Telepolice) getPodStatus(pod corev1.Pod) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-	if strings.Contains(stdout.String(), "sshd: telepresence") {
-		return true, nil
+
+	if !strings.Contains(stdout.String(), "sshd: telepresence") && strings.Contains(stdout.String(), "[ash]") {
+		return false, nil
 	}
 
-	return false, nil
+	return true, nil
 }
 
 func (te *Telepolice) cleanupOne(pod corev1.Pod, dryrun bool) error {


### PR DESCRIPTION
When telepresence start-up:

```
~ $ ps -elf
PID   USER     TIME   COMMAND
    1 telepres   0:00 {twistd} /usr/bin/python3.6 /usr/bin/twistd --pidfile= -n -y ./forwarder.py
    8 telepres   0:00 [sshd]
    9 telepres   0:00 /usr/sbin/sshd -e
```

When working telepresence pod:

```
~ $ ps -elf
PID   USER     TIME   COMMAND
    1 telepres   0:00 {twistd} /usr/bin/python3.6 /usr/bin/twistd --pidfile= -n -y ./forwarder.py
    8 telepres   0:00 [sshd]
    9 telepres   0:00 /usr/sbin/sshd -e
   14 telepres   0:00 [sshd]
   17 telepres   0:00 sshd: telepresence [priv]
   18 telepres   0:00 sshd: telepresence [priv]
   21 telepres   0:00 sshd: telepresence
   22 telepres   0:00 sshd: telepresence
   28 telepres   0:00 sshd: telepresence [priv]
   30 telepres   0:00 sshd: telepresence@notty
   31 telepres   0:00 ash -c /usr/lib/ssh/sftp-server
   32 telepres   0:00 /usr/lib/ssh/sftp-server
   34 telepres   0:00 sh
   39 telepres   0:00 ps -elf
```

When telepresence is not working:

```
~ $ ps -elf
PID   USER     TIME   COMMAND
    1 telepres   0:00 {twistd} /usr/bin/python3.6 /usr/bin/twistd --pidfile= -n -y ./forwarder.py
    8 telepres   0:00 [sshd]
    9 telepres   0:00 /usr/sbin/sshd -e
   14 telepres   0:00 [sshd]
   21 telepres   0:00 [sshd]
   22 telepres   0:00 [sshd]
   30 telepres   0:00 [sshd]
   31 telepres   0:00 [ash]
   34 telepres   0:00 sh
   43 telepres   0:00 ps -elf
```

Also have to make sure that the `[ash]` is present, start-up pod also kills.