### PR TITLE
Added a function to skip the health check immediately after starting the telepresence pod

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,12 +32,13 @@ import (
 )
 
 var (
-	useInClusterConfig bool
-	concurrency        int
-	telepoliceObj      *telepolice.Telepolice
-	namespaces         string
-	allNamespaces      bool
-	verbose            bool
+	useInClusterConfig           bool
+	concurrency                  int
+	ignorerablePodStartTimeOfSec int
+	telepoliceObj                *telepolice.Telepolice
+	namespaces                   string
+	allNamespaces                bool
+	verbose                      bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,6 +60,7 @@ func Execute() {
 func init() {
 	numCPU := runtime.NumCPU()
 	rootCmd.PersistentFlags().IntVarP(&concurrency, "concurrency", "c", numCPU, fmt.Sprintf("Multiple processing default: %d (runtime.NumCPU())", numCPU))
+	rootCmd.PersistentFlags().IntVar(&ignorerablePodStartTimeOfSec, "ignorerablePodStartTimeOfSec", 30, fmt.Sprintf("Pod immediately after startup is in preparation and passes health check for the specified number of seconds default: %d (runtime.NumCPU())", 30))
 	rootCmd.PersistentFlags().BoolVar(&useInClusterConfig, "use-in-cluster-config", false, "Use the service account kubernetes gives to pods")
 	rootCmd.PersistentFlags().StringVarP(&namespaces, "namespaces", "n", "default", "Target namespaces (e.g. ns1,ns2)")
 	rootCmd.PersistentFlags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Target all namespaces")
@@ -70,7 +72,7 @@ func strToSlice(s string) []string {
 }
 
 func initCommand() {
-	c := telepolice.NewConfig(concurrency)
+	c := telepolice.NewConfig(concurrency, ignorerablePodStartTimeOfSec)
 	var err error
 	if useInClusterConfig {
 		telepoliceObj, err = telepolice.NewByInClusterConfig(c)

--- a/telepolice/config.go
+++ b/telepolice/config.go
@@ -2,10 +2,13 @@ package telepolice
 
 type Config struct {
 	Concurrency int
+	// Pod immediately after startup is in preparation and passes health check for the specified number of seconds
+	IgnorerablePodStartTimeOfSec int
 }
 
-func NewConfig(concurrency int) *Config {
+func NewConfig(concurrency int, ignorerablePodStartTimeOfSec int) *Config {
 	return &Config{
-		Concurrency: concurrency,
+		Concurrency:                  concurrency,
+		IgnorerablePodStartTimeOfSec: ignorerablePodStartTimeOfSec,
 	}
 }

--- a/telepolice/telepolice.go
+++ b/telepolice/telepolice.go
@@ -23,10 +23,11 @@ import (
 )
 
 type Telepolice struct {
-	kubernetes  *kube.Kubernetes
-	namespaces  []string
-	concurrency int
-	verbose     bool
+	kubernetes                   *kube.Kubernetes
+	namespaces                   []string
+	concurrency                  int
+	ignorerablePodStartTimeOfSec int
+	verbose                      bool
 }
 
 func NewByKubeConfig(c *Config) (*Telepolice, error) {
@@ -219,10 +220,11 @@ func (te *Telepolice) WatchWithCleanup(dryrun bool, intervalSec int) error {
 
 func new(c *Config, kubernetes *kube.Kubernetes) (*Telepolice, error) {
 	return &Telepolice{
-		kubernetes:  kubernetes,
-		concurrency: c.Concurrency,
-		namespaces:  []string{"default"},
-		verbose:     false,
+		kubernetes:                   kubernetes,
+		concurrency:                  c.Concurrency,
+		ignorerablePodStartTimeOfSec: c.IgnorerablePodStartTimeOfSec,
+		namespaces:                   []string{"default"},
+		verbose:                      false,
 	}, nil
 }
 
@@ -245,8 +247,23 @@ func (te *Telepolice) getPods() ([]corev1.Pod, error) {
 	return pods, nil
 }
 
+func (te *Telepolice) checkPassageOfPodStartTime(now time.Time, podStartTime *metav1.Time) bool {
+	thresholdTime := podStartTime.Add(time.Duration(te.ignorerablePodStartTimeOfSec) * time.Second)
+	if now.Unix() > thresholdTime.Unix() {
+		return true
+	}
+
+	return false
+}
+
 func (te *Telepolice) getPodStatus(pod corev1.Pod) (bool, error) {
 	te.debug(fmt.Sprintf("telepolice.getPodStatus() %s", pod.Name))
+
+	if !te.checkPassageOfPodStartTime(time.Now(), pod.Status.StartTime) {
+		te.debug(fmt.Sprintf("The Pod will skip the check because it is not passage since the start %d seconds: %s", te.ignorerablePodStartTimeOfSec, pod.Name))
+		return true, nil
+	}
+
 	containerName := ""
 	for _, c := range pod.Spec.Containers {
 		if strings.Contains(c.Image, "telepresence-k8s") {

--- a/telepolice/telepolice.go
+++ b/telepolice/telepolice.go
@@ -286,12 +286,11 @@ func (te *Telepolice) getPodStatus(pod corev1.Pod) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-
-	if !strings.Contains(stdout.String(), "sshd: telepresence") && strings.Contains(stdout.String(), "[ash]") {
-		return false, nil
+	if strings.Contains(stdout.String(), "sshd: telepresence") {
+		return true, nil
 	}
 
-	return true, nil
+	return false, nil
 }
 
 func (te *Telepolice) cleanupOne(pod corev1.Pod, dryrun bool) error {

--- a/telepolice/telepolice_test.go
+++ b/telepolice/telepolice_test.go
@@ -3,6 +3,7 @@ package telepolice
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/takumakume/telepolice/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
@@ -112,5 +113,58 @@ func TestTelepolice_EnableVerbose(t *testing.T) {
 	te.EnableVerbose()
 	if te.verbose != true {
 		t.Errorf("telepolice.EnableVerbose() verbose is not enabled")
+	}
+}
+
+func TestTelepolice_checkPassageOfPodStartTime(t *testing.T) {
+	type fields struct {
+		kubernetes                   *kube.Kubernetes
+		namespaces                   []string
+		concurrency                  int
+		ignorerablePodStartTimeOfSec int
+		verbose                      bool
+	}
+	type args struct {
+		now          time.Time
+		podStartTime *metav1.Time
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "true",
+			fields: fields{ignorerablePodStartTimeOfSec: 30},
+			args: args{
+				podStartTime: &metav1.Time{time.Date(2020, 1, 1, 10, 20, 0, 0, time.UTC)}, // 2020-01-01 10:20:00
+				now:          time.Date(2020, 1, 1, 10, 20, 31, 0, time.UTC),              // 2020-01-01 10:20:31
+			},
+			want: true,
+		},
+		{
+			name:   "false",
+			fields: fields{ignorerablePodStartTimeOfSec: 30},
+			args: args{
+				podStartTime: &metav1.Time{time.Date(2020, 1, 1, 10, 20, 0, 0, time.UTC)}, // 2020-01-01 10:20:00
+				now:          time.Date(2020, 1, 1, 10, 20, 30, 0, time.UTC),              // 2020-01-01 10:20:30
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := &Telepolice{
+				kubernetes:                   tt.fields.kubernetes,
+				namespaces:                   tt.fields.namespaces,
+				concurrency:                  tt.fields.concurrency,
+				ignorerablePodStartTimeOfSec: tt.fields.ignorerablePodStartTimeOfSec,
+				verbose:                      tt.fields.verbose,
+			}
+			if got := te.checkPassageOfPodStartTime(tt.args.now, tt.args.podStartTime); got != tt.want {
+				t.Errorf("Telepolice.checkPassageOfPodStartTime() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Added a function to skip the health check immediately after starting the telepresence pod

In this case, there are patterns that are not considered.
https://github.com/takumakume/telepolice/pull/1  

