### PR TITLE
Get the information of the original deployment from annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ telepolice sees the state of sshd process.
 
 </details>
 
+## Add annotations to deployment
+
+```yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: app-deployment
+spec:
+  annotations:
+    telepolice/original-deployment: app-deployment
+    telepolice/original-deployment-replicas: 1
+...
+```
+
+Previously, metadata.selflink of last-applied-configuration of annotations was used, but it became deprecated.
+
 ## Usage
 
 ### Get telepresence resources


### PR DESCRIPTION
- last-applied-configuration metadata.selflink has been deprecated
- get the information of the original deployment from annotations

## Add annotations to deployment

```yaml
apiVersion: apps/v1beta1
kind: Deployment
metadata:
  name: app-deployment
spec:
  annotations:
    telepolice/original-deployment: app-deployment
    telepolice/original-deployment-replicas: 1
...
```